### PR TITLE
Update index.js

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -13,7 +13,7 @@ const MonoJS = {
           
             methods: {
                 $launchMono(options) {
-                    const connect = new Connect(publicKey, options);
+                    const connect = new Connect({key: publicKey, ...options});
                     connect.setup();
                     connect.open()
                 },


### PR DESCRIPTION
the Mono-Connect method accepting two parameters has been deprecated.
This PR aims to fix that.